### PR TITLE
Install documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,6 +2,7 @@
 - [Bernd Herrmann](https://github.com/bherrmann-iis), Fraunhofer IIS
 - Daniel Stadelmann, Fraunhofer IIS
 - Jochen Issing, Fraunhofer IIS
+- [Jo Jöns](https://github.com/jopejoe1), NixOS
 - Julian Zebelein, Fraunhofer IIS
 - [Moritz Fuchs](https://github.com/mfuchs-iis), Fraunhofer IIS
 - Ziad Shaban, Fraunhofer IIS

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -38,6 +38,18 @@ if(DOXYGEN_FOUND)
     VERBATIM
     DEPENDS ${PROJECT_NAME}_doc
   )
+
+  include(GNUInstallDirs)
+
+  install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+  )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/latex/refman.pdf
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+  )
 else()
   message("Doxygen need to be installed to generate the doxygen documentation")
 endif()


### PR DESCRIPTION
I'm currently packing this for NixOS and noticed that the documentation is not getting installed, even though it was set to build it. Added some CMake install commands to add the documentation to the CMake doc dir. So that I can easily install it when building it as a package.

Same as https://github.com/Fraunhofer-IIS/ilo/pull/1